### PR TITLE
The blue team column hides in the match breakdown when viewing remote events

### DIFF
--- a/lib/models/game-specifics/game-data.dart
+++ b/lib/models/game-specifics/game-data.dart
@@ -33,7 +33,7 @@ class GameData {
     }
   }
   
-  static List<Widget> getBreakdown(Match match, BuildContext context) {
+  static List<Widget> getBreakdown(Match match, BuildContext context, bool isRemote) {
     List<Widget> noData = [NoDataWidget(MdiIcons.ballotOutline, 'No Breakdown found')];
     if (match.gameData == null) {
       return noData;
@@ -46,7 +46,7 @@ class GameData {
       case '1920':
         return MatchBreakdown1920.getRows(match, context);
       case '2021':
-        return MatchBreakdown2021.getRows(match, context);
+        return MatchBreakdown2021.getRows(match, context, isRemote); // remote events were only introduced in 2020/2021
       default:
         return noData;
     }

--- a/lib/models/game-specifics/game-data.dart
+++ b/lib/models/game-specifics/game-data.dart
@@ -12,6 +12,7 @@ import 'package:toa_flutter/ui/views/match/years/match-breakdown-1718.dart';
 import 'package:toa_flutter/ui/views/match/years/match-breakdown-1819.dart';
 import 'package:toa_flutter/ui/views/match/years/match-breakdown-1920.dart';
 import 'package:toa_flutter/ui/views/match/years/match-breakdown-2021.dart';
+import 'package:toa_flutter/ui/views/match/years/remote-match-breakdown-2021.dart';
 
 class GameData {
 
@@ -46,7 +47,7 @@ class GameData {
       case '1920':
         return MatchBreakdown1920.getRows(match, context);
       case '2021':
-        return MatchBreakdown2021.getRows(match, context, isRemote); // remote events were only introduced in 2020/2021
+        return isRemote ? RemoteMatchBreakdown2021.getRows(match, context) : MatchBreakdown2021.getRows(match, context); // remote events were only introduced in 2020/2021
       default:
         return noData;
     }

--- a/lib/sort.dart
+++ b/lib/sort.dart
@@ -50,8 +50,16 @@ class Sort {
     int tournamentLevel2 = b.tournamentLevel;
     int matchNumber1 = int.parse(a.matchKey.split("-")[3].substring(1, 4));
     int matchNumber2 = int.parse(b.matchKey.split("-")[3].substring(1, 4));
+    int matchParticipant1 = int.parse(a.participants[0].teamKey);
+    int matchParticipant2 = int.parse(b.participants[0].teamKey);
+    bool isMatchRemote = a.participants.length == 1;
 
-    if (tournamentLevel1 == tournamentLevel2) {
+/**
+ * if a match is remote but has already been sorted by team number, it will skip to the next condition: match number.
+ */
+    if (tournamentLevel1 == tournamentLevel2 && isMatchRemote && matchParticipant1 != matchParticipant2) {
+      return matchParticipant1 < matchParticipant2 ? -1 : 1;
+    } else if (tournamentLevel1 == tournamentLevel2) {
       return matchNumber1 < matchNumber2 ? -1 : 1;
     } else if (tournamentLevel1 == MatchType.FINALS_MATCH) {
       return 1;

--- a/lib/ui/views/match/match-page.dart
+++ b/lib/ui/views/match/match-page.dart
@@ -117,10 +117,10 @@ class MatchPageState extends State<MatchPage> {
               })
             ]
                 : null),
-        body: buildInfo());
+        body: buildInfo(event.eventName.contains('REMOTE')));
   }
 
-  buildInfo() {
+  buildInfo(bool isRemote) {
     List<Widget> column = [];
     List<Widget> card = [];
 
@@ -192,7 +192,7 @@ class MatchPageState extends State<MatchPage> {
 
     // Match breakdown
     column.add(!loadingBreakdown
-        ? Column(children: GameData.getBreakdown(match, context))
+        ? Column(children: GameData.getBreakdown(match, context, isRemote))
         : Container(
         margin: EdgeInsets.only(top: 36, bottom: 24),
         child: Center(child: CircularProgressIndicator())));

--- a/lib/ui/views/match/match-page.dart
+++ b/lib/ui/views/match/match-page.dart
@@ -117,10 +117,10 @@ class MatchPageState extends State<MatchPage> {
               })
             ]
                 : null),
-        body: buildInfo(event.eventName.contains('REMOTE')));
+        body: buildInfo());
   }
 
-  buildInfo(bool isRemote) {
+  buildInfo() {
     List<Widget> column = [];
     List<Widget> card = [];
 
@@ -192,7 +192,7 @@ class MatchPageState extends State<MatchPage> {
 
     // Match breakdown
     column.add(!loadingBreakdown
-        ? Column(children: GameData.getBreakdown(match, context, isRemote))
+        ? Column(children: GameData.getBreakdown(match, context, match.participants.length == 1))
         : Container(
         margin: EdgeInsets.only(top: 36, bottom: 24),
         child: Center(child: CircularProgressIndicator())));

--- a/lib/ui/views/match/years/match-breakdown-2021.dart
+++ b/lib/ui/views/match/years/match-breakdown-2021.dart
@@ -94,13 +94,13 @@ class MatchBreakdown2021 {
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_end_position'),
-          red: getUltimateGoalWobbleString(details.red.wobbleRings1, local),
-          blue: getUltimateGoalWobbleString(details.blue.wobbleRings2, local),
+          red: getUltimateGoalWobbleString(details.red.wobbleEnd1, local),
+          blue: getUltimateGoalWobbleString(details.blue.wobbleEnd1, local),
           text: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_end_position'),
-          red: getUltimateGoalWobbleString(details.red.wobbleRings2, local),
-          blue: getUltimateGoalWobbleString(details.blue.wobbleRings2, local),
+          red: getUltimateGoalWobbleString(details.red.wobbleEnd2, local),
+          blue: getUltimateGoalWobbleString(details.blue.wobbleEnd2, local),
           text: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.power_shots'),

--- a/lib/ui/views/match/years/match-breakdown-2021.dart
+++ b/lib/ui/views/match/years/match-breakdown-2021.dart
@@ -6,7 +6,7 @@ import '../../../widgets/match-breakdown-row.dart';
 import 'package:toa_flutter/models/game-specifics/ultimategoal-match-details.dart';
 
 class MatchBreakdown2021 {
-  static List<Widget> getRows(Match match, BuildContext context, bool isRemote) {
+  static List<Widget> getRows(Match match, BuildContext context) {
     TOALocalizations local = TOALocalizations.of(context);
     UltimateGoalMatchDetails details = match.gameData;
     return <Widget>[
@@ -14,136 +14,114 @@ class MatchBreakdown2021 {
           name: local.get('breakdowns.autonomous'),
           red: match.redAutoScore,
           blue: match.blueAutoScore,
-          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_high'),
           red: details.red.autoTowerHigh,
           blue: details.blue.autoTowerHigh,
-          half: isRemote,
           points: 12),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_middle'),
           red: details.red.autoTowerMid,
           blue: details.blue.autoTowerMid,
-          half: isRemote,
           points: 6),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_low'),
           red: details.red.autoTowerLow,
           blue: details.blue.autoTowerLow,
-          half: isRemote,
           points: 3),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.power_shots'),
           red: details.red.autoPowerShotPoints ~/ 15,
           blue: details.blue.autoPowerShotPoints != null ? details.blue.autoPowerShotPoints ~/ 15 : 0,
-          half: isRemote,
           points: 15),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_delivered'),
           red: details.red.wobbleDelivered1,
           blue: details.blue.wobbleDelivered1,
-          half: isRemote,
           points: 15),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_delivered'),
           red: details.red.wobbleDelivered2,
           blue: details.blue.wobbleDelivered2,
-          half: isRemote,
           points: 15),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.robot_1_navigated'),
           red: details.red.navigated1,
           blue: details.blue.navigated1,
-          half: isRemote,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.robot_2_navigated'),
           red: details.red.navigated2,
           blue: details.blue.navigated2,
-          half: isRemote,
           points: 5),
 
       MatchBreakdownRow(
           name: local.get('breakdowns.teleop'),
           red: match.redTeleScore,
           blue: match.blueTeleScore,
-          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_high'),
           red: details.red.dcTowerHigh,
           blue: details.blue.dcTowerHigh,
-          half: isRemote,
           points: 6),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_middle'),
           red: details.red.dcTowerMid,
           blue: details.blue.dcTowerMid,
-          half: isRemote,
           points: 4),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_low'),
           red: details.red.dcTowerLow,
           blue: details.blue.dcTowerLow,
-          half: isRemote,
           points: 2),
 
       MatchBreakdownRow(
           name: local.get('breakdowns.end'),
           red: match.redEndScore,
           blue: match.blueEndScore,
-          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_rings'),
           red: details.red.wobbleRings1,
           blue: details.blue.wobbleRings1,
-          half: isRemote,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_rings'),
           red: details.red.wobbleRings2,
           blue: details.blue.wobbleRings2,
-          half: isRemote,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_end_position'),
           red: getUltimateGoalWobbleString(details.red.wobbleRings1, local),
           blue: getUltimateGoalWobbleString(details.blue.wobbleRings2, local),
-          half: isRemote,
           text: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_end_position'),
           red: getUltimateGoalWobbleString(details.red.wobbleRings2, local),
           blue: getUltimateGoalWobbleString(details.blue.wobbleRings2, local),
-          half: isRemote,
           text: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.power_shots'),
           red: details.red.endPowerShotPoints ~/ 15,
           blue: details.blue.endPowerShotPoints != null ? details.blue.endPowerShotPoints ~/ 15 : 0,
-          half: isRemote,
           points: 15),
 
       MatchBreakdownRow(
           name: local.get('breakdowns.penalty'),
           red: match.redPenalty,
           blue: match.bluePenalty,
-          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.minor_penalty'),
-          red: isRemote ? details.redMinPen : details.blueMinPen,
-          blue: isRemote ? details.blueMinPen : details.redMinPen,
-          half: isRemote,
+          red: details.blueMinPen,
+          blue: details.redMinPen,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.major_penalty'),
-          red: isRemote ? details.redMajPen : details.blueMajPen,
-          blue: isRemote ? details.blueMajPen : details.redMajPen,
-          half: isRemote,
+          red: details.blueMajPen,
+          blue: details.redMajPen,
           points: 20),
     ];
   }

--- a/lib/ui/views/match/years/match-breakdown-2021.dart
+++ b/lib/ui/views/match/years/match-breakdown-2021.dart
@@ -6,7 +6,7 @@ import '../../../widgets/match-breakdown-row.dart';
 import 'package:toa_flutter/models/game-specifics/ultimategoal-match-details.dart';
 
 class MatchBreakdown2021 {
-  static List<Widget> getRows(Match match, BuildContext context) {
+  static List<Widget> getRows(Match match, BuildContext context, bool isRemote) {
     TOALocalizations local = TOALocalizations.of(context);
     UltimateGoalMatchDetails details = match.gameData;
     return <Widget>[
@@ -14,114 +14,136 @@ class MatchBreakdown2021 {
           name: local.get('breakdowns.autonomous'),
           red: match.redAutoScore,
           blue: match.blueAutoScore,
+          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_high'),
           red: details.red.autoTowerHigh,
           blue: details.blue.autoTowerHigh,
+          half: isRemote,
           points: 12),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_middle'),
           red: details.red.autoTowerMid,
           blue: details.blue.autoTowerMid,
+          half: isRemote,
           points: 6),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_low'),
           red: details.red.autoTowerLow,
           blue: details.blue.autoTowerLow,
+          half: isRemote,
           points: 3),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.power_shots'),
           red: details.red.autoPowerShotPoints ~/ 15,
-          blue: details.blue.autoPowerShotPoints ~/ 15,
+          blue: details.blue.autoPowerShotPoints != null ? details.blue.autoPowerShotPoints ~/ 15 : 0,
+          half: isRemote,
           points: 15),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_delivered'),
           red: details.red.wobbleDelivered1,
           blue: details.blue.wobbleDelivered1,
+          half: isRemote,
           points: 15),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_delivered'),
           red: details.red.wobbleDelivered2,
           blue: details.blue.wobbleDelivered2,
+          half: isRemote,
           points: 15),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.robot_1_navigated'),
           red: details.red.navigated1,
           blue: details.blue.navigated1,
+          half: isRemote,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.robot_2_navigated'),
           red: details.red.navigated2,
           blue: details.blue.navigated2,
+          half: isRemote,
           points: 5),
 
       MatchBreakdownRow(
           name: local.get('breakdowns.teleop'),
           red: match.redTeleScore,
           blue: match.blueTeleScore,
+          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_high'),
           red: details.red.dcTowerHigh,
           blue: details.blue.dcTowerHigh,
+          half: isRemote,
           points: 6),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_middle'),
           red: details.red.dcTowerMid,
           blue: details.blue.dcTowerMid,
+          half: isRemote,
           points: 4),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.rings_low'),
           red: details.red.dcTowerLow,
           blue: details.blue.dcTowerLow,
+          half: isRemote,
           points: 2),
 
       MatchBreakdownRow(
           name: local.get('breakdowns.end'),
           red: match.redEndScore,
           blue: match.blueEndScore,
+          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_rings'),
           red: details.red.wobbleRings1,
           blue: details.blue.wobbleRings1,
+          half: isRemote,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_rings'),
           red: details.red.wobbleRings2,
           blue: details.blue.wobbleRings2,
+          half: isRemote,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_end_position'),
           red: getUltimateGoalWobbleString(details.red.wobbleRings1, local),
           blue: getUltimateGoalWobbleString(details.blue.wobbleRings2, local),
+          half: isRemote,
           text: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_end_position'),
           red: getUltimateGoalWobbleString(details.red.wobbleRings2, local),
           blue: getUltimateGoalWobbleString(details.blue.wobbleRings2, local),
+          half: isRemote,
           text: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.power_shots'),
           red: details.red.endPowerShotPoints ~/ 15,
-          blue: details.blue.endPowerShotPoints ~/ 15,
+          blue: details.blue.endPowerShotPoints != null ? details.blue.endPowerShotPoints ~/ 15 : 0,
+          half: isRemote,
           points: 15),
 
       MatchBreakdownRow(
           name: local.get('breakdowns.penalty'),
           red: match.redPenalty,
           blue: match.bluePenalty,
+          half: isRemote,
           title: true),
       MatchBreakdownRow(
           name: local.get('breakdowns.minor_penalty'),
-          red: details.blueMinPen,
-          blue: details.redMinPen,
+          red: isRemote ? details.redMinPen : details.blueMinPen,
+          blue: isRemote ? details.blueMinPen : details.redMinPen,
+          half: isRemote,
           points: 5),
       MatchBreakdownRow(
           name: local.get('breakdowns.major_penalty'),
-          red: details.blueMajPen,
-          blue: details.redMajPen,
+          red: isRemote ? details.redMajPen : details.blueMajPen,
+          blue: isRemote ? details.blueMajPen : details.redMajPen,
+          half: isRemote,
           points: 20),
     ];
   }
@@ -132,9 +154,8 @@ class MatchBreakdown2021 {
           return local.get('breakdowns.ultimategoal.start_line') + ' (+5)';
         case 2:
           return local.get('breakdowns.ultimategoal.drop_zone') + ' (+20)';
-        case 0:
+        default:
           return local.get('breakdowns.ultimategoal.not_scored');
       }
-    return local.get('breakdowns.ultimategoal.not_scored');
   }
 }

--- a/lib/ui/views/match/years/remote-match-breakdown-2021.dart
+++ b/lib/ui/views/match/years/remote-match-breakdown-2021.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+
+import '../../../../internationalization/localizations.dart';
+import '../../../../models/match.dart';
+import '../../../widgets/remote-match-breakdown-row.dart';
+import 'package:toa_flutter/models/game-specifics/ultimategoal-match-details.dart';
+
+class RemoteMatchBreakdown2021 {
+  static List<Widget> getRows(
+      Match match, BuildContext context) {
+    TOALocalizations local = TOALocalizations.of(context);
+    UltimateGoalMatchDetails details = match.gameData;
+    return <Widget>[
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.autonomous'),
+          team: match.redAutoScore,
+          title: true),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.rings_high'),
+          team: details.red.autoTowerHigh,
+          points: 12),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.rings_middle'),
+          team: details.red.autoTowerMid,
+          points: 6),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.rings_low'),
+          team: details.red.autoTowerLow,
+          points: 3),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.power_shots'),
+          team: details.red.autoPowerShotPoints != null
+              ? details.red.autoPowerShotPoints ~/ 15
+              : 0,
+          points: 15),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.wobble_goal_1_delivered'),
+          team: details.red.wobbleDelivered1,
+          points: 15),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.wobble_goal_2_delivered'),
+          team: details.red.wobbleDelivered2,
+          points: 15),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.robot_1_navigated'),
+          team: details.red.navigated1,
+          points: 5),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.robot_2_navigated'),
+          team: details.red.navigated2,
+          points: 5),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.teleop'),
+          team: match.redTeleScore,
+          title: true),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.rings_high'),
+          team: details.red.dcTowerHigh,
+          points: 6),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.rings_middle'),
+          team: details.red.dcTowerMid,
+          points: 4),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.rings_low'),
+          team: details.red.dcTowerLow,
+          points: 2),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.end'),
+          team: match.redEndScore,
+          title: true),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.wobble_goal_1_rings'),
+          team: details.red.wobbleRings1,
+          points: 5),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.wobble_goal_2_rings'),
+          team: details.red.wobbleRings2,
+          points: 5),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.wobble_goal_1_end_position'),
+          team: getUltimateGoalWobbleString(details.red.wobbleRings2, local),
+          text: true),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.wobble_goal_2_end_position'),
+          team: getUltimateGoalWobbleString(details.red.wobbleRings2, local),
+          text: true),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.ultimategoal.power_shots'),
+          team: details.red.endPowerShotPoints != null
+              ? details.red.endPowerShotPoints ~/ 15
+              : 0,
+          points: 15),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.penalty'),
+          team: match.redPenalty,
+          title: true),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.minor_penalty'),
+          team: details.redMinPen,
+          points: 5),
+      RemoteMatchBreakdownRow(
+          name: local.get('breakdowns.major_penalty'),
+          team: details.redMajPen,
+          points: 20),
+    ];
+  }
+
+  static getUltimateGoalWobbleString(int key, TOALocalizations local) {
+    switch (key) {
+      case 1:
+        return local.get('breakdowns.ultimategoal.start_line') + ' (+5)';
+      case 2:
+        return local.get('breakdowns.ultimategoal.drop_zone') + ' (+20)';
+      default:
+        return local.get('breakdowns.ultimategoal.not_scored');
+    }
+  }
+}

--- a/lib/ui/views/match/years/remote-match-breakdown-2021.dart
+++ b/lib/ui/views/match/years/remote-match-breakdown-2021.dart
@@ -46,10 +46,6 @@ class RemoteMatchBreakdown2021 {
           team: details.red.navigated1,
           points: 5),
       RemoteMatchBreakdownRow(
-          name: local.get('breakdowns.ultimategoal.robot_2_navigated'),
-          team: details.red.navigated2,
-          points: 5),
-      RemoteMatchBreakdownRow(
           name: local.get('breakdowns.teleop'),
           team: match.redTeleScore,
           title: true),
@@ -79,11 +75,11 @@ class RemoteMatchBreakdown2021 {
           points: 5),
       RemoteMatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_1_end_position'),
-          team: getUltimateGoalWobbleString(details.red.wobbleRings2, local),
+          team: getUltimateGoalWobbleString(details.red.wobbleEnd1, local),
           text: true),
       RemoteMatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.wobble_goal_2_end_position'),
-          team: getUltimateGoalWobbleString(details.red.wobbleRings2, local),
+          team: getUltimateGoalWobbleString(details.red.wobbleEnd2, local),
           text: true),
       RemoteMatchBreakdownRow(
           name: local.get('breakdowns.ultimategoal.power_shots'),

--- a/lib/ui/widgets/match-breakdown-row.dart
+++ b/lib/ui/widgets/match-breakdown-row.dart
@@ -11,7 +11,7 @@ int FALSE_VALUE = -2000;
 
 class MatchBreakdownRow extends StatelessWidget {
 
-  MatchBreakdownRow({dynamic red, dynamic blue, this.points, this.name, this.title=false, this.text=false}) {
+  MatchBreakdownRow({dynamic red, dynamic blue, this.points, this.name, this.title=false, this.text=false, this.half=false}) {
     if (red is bool && !text) {
       this.red = red ? TRUE_VALUE : FALSE_VALUE;
     } else if (red is String && text) {
@@ -37,6 +37,7 @@ class MatchBreakdownRow extends StatelessWidget {
   final String name;
   final bool title;
   final bool text;
+  final bool half;
 
   TOALocalizations local;
   ThemeData theme;
@@ -51,8 +52,10 @@ class MatchBreakdownRow extends StatelessWidget {
         this.text ? buildText(redText, Alliance.RED)
             : buildPoints(red, points, Alliance.RED));
     row.add(buildName(name));
-    row.add(this.text ? buildText(blueText, Alliance.BLUE)
-        : buildPoints(blue, points, Alliance.BLUE));
+    if (!half) {
+      row.add(this.text ? buildText(blueText, Alliance.BLUE)
+          : buildPoints(blue, points, Alliance.BLUE));
+    }
 
     return IntrinsicHeight(
       child: Row(
@@ -77,7 +80,7 @@ class MatchBreakdownRow extends StatelessWidget {
     } else if (title) {
       text = '$missions ${local.get('breakdowns.points')}';
     } else if (missions != 0) {
-      int total = missions * points;
+      int total = missions != null ? missions * points : 0;
       text = '$missions (${total > 0 ? '+' : ''}$total)';
     }
 

--- a/lib/ui/widgets/match-list-item.dart
+++ b/lib/ui/widgets/match-list-item.dart
@@ -24,6 +24,7 @@ class MatchListItem extends StatelessWidget {
     List<Widget> row = [];
     List<Widget> redRow = [];
     List<Widget> blueRow = [];
+    List<Widget> orangeRow = [];
 
     if (participants.length == 4) {
       redRow.add(bulidTeam(0, participants, context));
@@ -41,11 +42,11 @@ class MatchListItem extends StatelessWidget {
       blueRow.add(bulidTeam(4, participants, context));
       blueRow.add(bulidTeam(5, participants, context));
     } else if (participants.length == 1) {
-      blueRow.add(bulidTeam(0, participants, context));
+      orangeRow.add(bulidTeam(0, participants, context));
     }
 
     if (participants.length == 1) {
-      blueRow.add(bulidPoints(match.redScore.toString()));
+      orangeRow.add(bulidPoints(match.redScore.toString()));
     } else {
       redRow.add(bulidPoints(match.redScore.toString()));
       blueRow.add(bulidPoints(match.blueScore.toString()));
@@ -73,26 +74,17 @@ class MatchListItem extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          Container(
-            decoration: BoxDecoration(
-              color: TOAColors.Colors().lighterRed,
-              border: points && match.redScore > match.blueScore ? Border.all(color: TOAColors.Colors().red, width: 2) : null
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.max,
-              children: redRow
-            )
+          buildRow(
+            children: redRow,
+            color: TOAColors.Colors().lighterRed,
+            border: points && match.redScore > match.blueScore ? Border.all(color: TOAColors.Colors().red, width: 2) : null
           ),
-          Container(
-            decoration: BoxDecoration(
-              color: TOAColors.Colors().lighterBlue,
-              border: points && match.blueScore > match.redScore ? Border.all(color: TOAColors.Colors().blue, width: 2) : null
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.max,
-              children: blueRow
-            )
-          )
+          buildRow(
+            children: blueRow,
+            color: TOAColors.Colors().lighterBlue,
+            border: points && match.blueScore > match.redScore ? Border.all(color: TOAColors.Colors().blue, width: 2) : null
+          ),
+          buildRow(children: orangeRow, color: (Theme.of(context).brightness == Brightness.light) ? TOAColors.Colors().toaColors.shade100 : Colors.black.withOpacity(0.12))
         ]
       )
     ));
@@ -162,5 +154,22 @@ class MatchListItem extends StatelessWidget {
         )
       )
     );
+  }
+
+  Widget buildRow({@required List<Widget> children, @required Color color, BoxBorder border,}) {
+    if (children.isNotEmpty) {
+      return Container(
+        decoration: BoxDecoration(
+          color: color,
+          border: border
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          children: children
+        )
+      );
+    } else {
+      return Container();
+    }
   }
 }

--- a/lib/ui/widgets/match-list-item.dart
+++ b/lib/ui/widgets/match-list-item.dart
@@ -40,10 +40,16 @@ class MatchListItem extends StatelessWidget {
       blueRow.add(bulidTeam(3, participants, context));
       blueRow.add(bulidTeam(4, participants, context));
       blueRow.add(bulidTeam(5, participants, context));
+    } else if (participants.length == 1) {
+      blueRow.add(bulidTeam(0, participants, context));
     }
 
-    redRow.add(bulidPoints(match.redScore.toString()));
-    blueRow.add(bulidPoints(match.blueScore.toString()));
+    if (participants.length == 1) {
+      blueRow.add(bulidPoints(match.redScore.toString()));
+    } else {
+      redRow.add(bulidPoints(match.redScore.toString()));
+      blueRow.add(bulidPoints(match.blueScore.toString()));
+    }
 
     if (!justTable) {
       // Match name

--- a/lib/ui/widgets/remote-match-breakdown-row.dart
+++ b/lib/ui/widgets/remote-match-breakdown-row.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+
+import '../../internationalization/localizations.dart';
+import '../colors.dart' as TOAColors;
+
+int TRUE_VALUE = -1000;
+int FALSE_VALUE = -2000;
+
+class RemoteMatchBreakdownRow extends StatelessWidget {
+
+  RemoteMatchBreakdownRow({dynamic team, this.points, this.name, this.title=false, this.text=false}) {
+    if (team is bool && !text) {
+      this.team = team ? TRUE_VALUE : FALSE_VALUE;
+    } else if (team is String && text) {
+      this.teamText = team;
+    } else {
+      this.team = team;
+    }
+  }
+
+  int team;
+  String teamText;
+  final int points;
+  final String name;
+  final bool title;
+  final bool text;
+
+  TOALocalizations local;
+  ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    local = TOALocalizations.of(context);
+    theme = Theme.of(context);
+    List<Widget> row = [];
+
+    row.add(buildName(name));
+    row.add(this.text ? buildText(teamText)
+        : buildPoints(team, points));
+
+    return IntrinsicHeight(
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: row
+      ),
+    );
+  }
+
+
+  Widget buildPoints(int missions, int points) {
+    String text = '0';
+    bool isTure = missions == TRUE_VALUE;
+    bool isFalse = missions == FALSE_VALUE;
+    bool isTrueFalse = isTure || isFalse;
+
+    if (isFalse) {
+      text = '';
+    } else if (isTure) {
+      text = ' (${points > 0 ? '+' : ''}$points)';
+    } else if (title) {
+      text = '$missions ${local.get('breakdowns.points')}';
+    } else if (missions != 0) {
+      int total = missions != null ? missions * points : 0;
+      text = '$missions (${total > 0 ? '+' : ''}$total)';
+    }
+
+    return Expanded(
+      flex: 3,
+      child: Container(
+        padding: EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: getColor(),
+          border: getBorder()
+        ),
+        child: Row(
+//          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            if (isTrueFalse)
+            Icon(
+              isTure ? Icons.check : Icons.close
+            ),
+            Text(
+              text,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontWeight: title ? FontWeight.w600 : FontWeight.normal)
+            )
+          ]
+        )
+      )
+    );
+  }
+
+  Widget buildText(String text) {
+    return Expanded(
+      flex: 3,
+      child: Container(
+        padding: EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: getColor(),
+          border: getBorder()
+        ),
+        child: Row(
+          //mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              text,
+              textAlign: TextAlign.center,
+              style: TextStyle(fontWeight: title ? FontWeight.w600 : FontWeight.normal)
+            )
+          ]
+        )
+      )
+    );
+  }
+
+  Widget buildName(String name) {
+    return Expanded(
+      flex: 4,
+      child:
+      Container(
+        decoration: BoxDecoration(
+          color: Colors.black.withOpacity(title ? 0.08 : 0),
+          border: getBorder()
+        ),
+        child: Padding(
+          padding: EdgeInsets.all(12),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                name,
+                textAlign: TextAlign.center,
+                style: TextStyle(fontWeight: title ? FontWeight.w600 : FontWeight.normal)
+              )
+            ]
+          )
+        )
+      )
+    );
+  }
+
+  Border getBorder() {
+    return title ? null : Border(bottom: BorderSide(width: 0.4, color: Colors.black12));
+  }
+
+  Color getColor() {
+    // I'm not sure which color to set this to so I'm going to leave it as blue.
+    return this.title ? TOAColors.Colors().lightBlue : TOAColors.Colors().lighterBlue;
+  }
+}

--- a/lib/ui/widgets/remote-match-breakdown-row.dart
+++ b/lib/ui/widgets/remote-match-breakdown-row.dart
@@ -150,7 +150,12 @@ class RemoteMatchBreakdownRow extends StatelessWidget {
   }
 
   Color getColor() {
-    // I'm not sure which color to set this to so I'm going to leave it as blue.
-    return this.title ? TOAColors.Colors().lightBlue : TOAColors.Colors().lighterBlue;
+    if (theme.brightness == Brightness.light) {
+      return this.title
+          ? TOAColors.Colors().toaColors.shade300
+          : TOAColors.Colors().toaColors.shade200;
+    } else {
+      return Colors.black.withOpacity(this.title ? 0.16 : 0.08);
+    }
   }
 }


### PR DESCRIPTION
the latest build of the app's match breakdown completely breaks in remote events. It now just hides the blue team column completely instead